### PR TITLE
Removing ios 8 platform specific

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,7 +1,5 @@
 use_frameworks!
 
-platform :ios, '8.0'
-
 pod 'MiniTabBar', :git => 'https://github.com/henrychavez/MiniTabBar.git'
 
 post_install do |installer|


### PR DESCRIPTION
I had an issue with another plugin that also was specifying the platform into its Podfile, causing me error when putting together into one file, saying that the platform specification was duplicated.

Another case scenario could be if other plugin specifies `platform :ios, '9.0'`, when running `tns run ios` it wont install the pods given that this plugin is requiring ios 8.

Not sure if this is the best approach but I think that plugins should not specify the platform version and instead relay on the project's deployment target.