### PR TITLE
Scope the SWIFT_VERSION setting to this Pod only

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -4,8 +4,10 @@ pod 'MaterialComponents/BottomNavigation'
 
 post_install do |installer|
     installer.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings['SWIFT_VERSION'] = '4.0'
+        if target.name == 'MaterialComponents'
+            target.build_configurations.each do |config|
+                config.build_settings['SWIFT_VERSION'] = '4.0'
+            end
         end
     end
 end


### PR DESCRIPTION
Hi!

Thanks a bunch for sharing this plugin with the world - I for one appreciate your efforts very much!

Can you do me a favor and merge this PR and release a new version to npm?

It solves a compatibility issue with any other plugin using Pods that need a different SWIFT version than the one this plugin forces the entire project to work. In short, this PR only forces the SWIFT version of the Pod using in this plugin.

Thanks again,
Eddy