### PR TITLE
Fixed Typescript Declaration File

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 import { BottomNavigationBarBase } from './lib/base/bottom-navigation-bar.base';
 import { BottomNavigationTabBase } from './lib/base/bottom-navigation-tab.base';
+import { EventData, Color } from 'tns-core-modules/ui/core/view';
 import {
   TabSelectedEventData,
   TabPressedEventData,
@@ -18,8 +19,8 @@ export declare class BottomNavigationBar extends BottomNavigationBarBase {
   readonly items: BottomNavigationTab[];
   selectedTabIndex: number;
   titleVisibility: TitleVisibility;
-  activeColor: string;
-  inactiveColor: string;
+  activeColor: Color;
+  inactiveColor: Color;
   backgroundColor: Color;
   selectTab(index: number): void;
   showBadge(index: number, value?: number): void;


### PR DESCRIPTION
Just updated from 1.5.1 to 2.0.3 and received some new errors complaining about type definitions. Figured this was simple enough to fix and updated `index.d.ts`

```
ERROR in node_modules/nativescript-bottom-navigation/index.d.ts(21,3): error TS2416: Property 'activeColor' in type 'BottomNavigationBar' is not assignable to the same property in base type 'BottomNavigationBarBase'.
  Type 'string' is not assignable to type 'Color'.
node_modules/nativescript-bottom-navigation/index.d.ts(22,3): error TS2416: Property 'inactiveColor' in type 'BottomNavigationBar' is not assignable to the same property in base type 'BottomNavigationBarBase'.
  Type 'string' is not assignable to type 'Color'.
node_modules/nativescript-bottom-navigation/index.d.ts(23,20): error TS2304: Cannot find name 'Color'.
node_modules/nativescript-bottom-navigation/index.d.ts(46,22): error TS2304: Cannot find name 'EventData'.
```
